### PR TITLE
Changed onBlur so it works with current Atom version

### DIFF
--- a/lib/components/AtomInput.js
+++ b/lib/components/AtomInput.js
@@ -188,7 +188,7 @@ export default class AtomInput extends React.Component {
   }
 
   _onBlur = (event) => {
-    if (event.relatedTarget === this.root.hiddenInputElement) {
+    if (event.relatedTarget === this.root || event.target === this.root) {
       return;
     }
 


### PR DESCRIPTION
I had the same issue as described in the last few comments in #136 

This PR solves issue  #136 for me. 

this.root.hiddenInputElement is always undefined, since it disappeared with this commit from Atom: https://github.com/atom/atom/commit/32f03c8a22e8aa370a546d55ab18db53f4ae8a79#diff-bf91f5fa5acc116ef9ee941e25c5aa4dL134

